### PR TITLE
Added windows support for build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "run": "ts-node index.ts",
     "lint": "eslint index.ts src/**/*.ts",
     "build": "tsc && cp -R public ./build",
+    "build_win": "tsc && xcopy /y public \"build\\public\\\"",
     "dev": "nodemon",
     "dev:debug": "nodemon --inspect",
     "test": "jest",


### PR DESCRIPTION
"cp" is only supported by unix systems. I added a build script command for windows.