### PR TITLE
Remove server reference from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The integration requires two parts: The abaplint Server (this project) and the [
 
 ![Components](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/abaplint/abaplint-sci-server/master/docs/components.iuml)
 
-**Important:** The code under test leaves your ABAP system! Be sure to use a secure and controllable abaplint Server. For a test, you might use the common server at [http://sci.abaplint.org/](http://sci.abaplint.org/) (but please don't post any proprietary code).
+**Important:** The code under test leaves your ABAP system! Be sure to use a secure and controllable abaplint Server. 
 
 ## Deployment Options
 


### PR DESCRIPTION
The Testserver [https://sci.abaplint.app](https://sci.abaplint.app/) is no longer available, so its reference should be removed. 

Closes #1575 